### PR TITLE
modified to able to parse code including multibyte chars

### DIFF
--- a/lib/src/mpm/emv_parser.dart
+++ b/lib/src/mpm/emv_parser.dart
@@ -11,8 +11,8 @@ const int valueLengthWordCount = 2;
 ParserModel newParser(String payload) {
   return ParserModel(
     current: -1,
-    max: utf8.encode(payload).length,
-    source: utf8.encode(payload),
+    max: payload.runes.length,
+    source: payload.runes.toList(),
     error: null,
   );
 }
@@ -109,7 +109,7 @@ String pValue(ParserModel? p) {
       p.error = outOfRangeErr(fnValue, p.current!, p.max!, start, end);
       return "";
     }
-    return utf8.decode(p.source!.sublist(start, end));
+    return String.fromCharCodes(p.source!.sublist(start, end));
   }
   return "";
 }

--- a/test/emvqrcode_test.dart
+++ b/test/emvqrcode_test.dart
@@ -142,6 +142,14 @@ void main() {
     expect(emvdecode.emvqr, isNotNull);
   });
 
+  test("decode emvqr with multi-byte chars", () {
+    final String data =
+        "000600000001021126320011com.example0113aaaaaaaaaaaaa5204549953033915405123455802JP5920ShopName in Japanese6005Tokyo6108111-111164230002JA0107日本語のネーム0202東京6304442A";
+    final emvDecode = EMVMPM.decode(data);
+    print("result -------> ${emvDecode.toJson()}");
+    expect(emvDecode.emvqr, isNotNull);
+  });
+
   test(" wrong emvqr ", () {
     String wrongData =
         "00020101021138670016A00526628466257701082771041802030010324ZPOSUALNJBWWVYSEIRIESGFE6304D1B9";


### PR DESCRIPTION
@LaoitdevOpen Hello, I am Rie Ono from Japan.
Thank you for the implementation of EMVCo library! I would like to use this library.
I noticed that I could not parse QR codes including multi-byte chars like Japanese.
The cause of this issue, utf8.encode() will return the bytes of only alphanumeric chars.
Could you check my fix?
Best Regards,