### PR TITLE
fix: invalid length value

### DIFF
--- a/lib/src/mpm/emv_types.dart
+++ b/lib/src/mpm/emv_types.dart
@@ -177,10 +177,7 @@ EMVDeCode parseEMVQR(String payload) {
 }
 
 String l(String value) {
-  if (utf8.encode(value).length > 10) {
-    return "${utf8.encode(value).length}";
-  }
-  return "0${utf8.encode(value).length}";
+  return "${utf8.encode(value).length}".padLeft(2, '0');
 }
 
 /// set tlv value


### PR DESCRIPTION
thanks for the library, it's very helpful. but there is a problem when specifying length value of 10 chars which causes invalid qr.

example value: 'ABCDEFGHIJ'
expected result: '10'
actual result: '010'